### PR TITLE
[PMW-8] Microservice (backend) opzetten voor planmonitor wonen

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -32,7 +32,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.19.0
         # docker run --rm -v trivy_cache:/root/.cache/ aquasec/trivy image docker.b3p.nl/b3partners/planmonitor-wonen-api:snapshot
         with:
-          image-ref: 'docker.b3p.nl/b3partners/planmonitor-wonen-api:snapshot'
+          image-ref: 'ghcr.io/b3partners/planmonitor-wonen-api:snapshot'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'

--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -116,6 +116,13 @@ jobs:
         with:
           maven-version: '3.9.6'
 
+      - name: 'Log in to GitHub container registry'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push
         # no need to run any QC or tests
         # note deploy will deploy both Maven artifact as well as Docker image
@@ -127,6 +134,7 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64
           mvn -B -V -fae -DskipTests -DskipITs -DskipQA=true -Pqa-skip clean deploy --settings .github/maven-settings.xml
+          docker push ghcr.io/b3partners/planmonitor-wonen-api:snapshot
 
       - name: 'Publish SBOM'
         uses: DependencyTrack/gh-upload-sbom@v3

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@ SPDX-License-Identifier: MIT
         <oracle-database.version>23.3.0.23.09</oracle-database.version>
         <postgresql.version>42.7.3</postgresql.version>
         <!-- <snakeyaml.version>2.2</snakeyaml.version>-->
-        <spring-security.version>6.2.3</spring-security.version>
+        <spring-security.version>6.2.4</spring-security.version>
         <spring-data-bom.version>2023.1.5</spring-data-bom.version>
         <spring-hateoas.version>2.2.2</spring-hateoas.version>
         <okhttp.version>5.0.0-alpha.12</okhttp.version>
@@ -159,7 +159,7 @@ SPDX-License-Identifier: MIT
         <!-- suppress missing javadoc warnings -->
         <javadoc.doclint>all,-missing</javadoc.doclint>
         <!-- docker.b3p.nl or alternatively ghcr.io  -->
-        <docker.deploy.repo>docker.b3p.nl</docker.deploy.repo>
+        <docker.deploy.repo>ghcr.io</docker.deploy.repo>
         <docker.skip>false</docker.skip>
         <docker.pull.policy>ALWAYS</docker.pull.policy>
         <!-- skip QA checks -->
@@ -197,12 +197,21 @@ SPDX-License-Identifier: MIT
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -215,7 +224,7 @@ SPDX-License-Identifier: MIT
         <repository>
             <id>B3Partners</id>
             <name>Releases hosted by B3Partners</name>
-            <url>https://repo.b3p.nl/nexus/repository/private/</url>
+            <url>https://repo.b3p.nl/nexus/repository/public/</url>
         </repository>
     </repositories>
     <build>
@@ -398,12 +407,21 @@ SPDX-License-Identifier: MIT
                     <!--max attempts to check if application is up, default 60 -->
                     <maxAttempts>120</maxAttempts>
                     <image>
-                        <name>${docker.deploy.repo}/b3partners/${project.artifactId}:${project.version}</name>
+                        <name>${docker.deploy.repo}/b3partners/${project.artifactId}:snapshot</name>
                         <!-- TODO setup in release profile -->
                         <!--<tags>${docker.deploy.repo}/b3partners/${project.artifactId}:latest</tags>-->
-                        <!-- TODO setup w/ true inrelease profile to push image -->
+                        <!-- TODO setup w/ true in release profile to push image -->
                         <publish>false</publish>
-                        <env />
+                        <env>
+                            <BP_OCI_SOURCE>${project.scm.url}</BP_OCI_SOURCE>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <BP_OCI_REVISION>${git.commit.id.abbrev}</BP_OCI_REVISION>
+                            <BP_OCI_VERSION>${project.version}</BP_OCI_VERSION>
+                            <BP_OCI_CREATED>${project.build.outputTimestamp}</BP_OCI_CREATED>
+                            <BP_OCI_URL>${docker.deploy.repo}/b3partners/${project.artifactId}:${project.version}</BP_OCI_URL>
+                            <BP_OCI_DESCRIPTION>${project.description}</BP_OCI_DESCRIPTION>
+                            <BP_OCI_LICENSES>${project.licenses}</BP_OCI_LICENSES>
+                        </env>
                         <pullPolicy>${docker.pull.policy}</pullPolicy>
                     </image>
                     <layers>
@@ -685,15 +703,16 @@ SPDX-License-Identifier: MIT
                                 </bannedDependencies>
                                 <banTransitiveDependencies>
                                     <excludes>
+                                        <exclude>org.springframework.boot:spring-boot-starter</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-web</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-data-jpa</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-actuator</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-test</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-validation</exclude>
                                         <exclude>org.springframework.boot:spring-boot-starter-aop</exclude>
+                                        <exclude>org.springframework.boot:spring-boot-starter-security</exclude>
+                                        <exclude>org.springframework.security:spring-security-test</exclude>
                                         <exclude>io.micrometer:micrometer-registry-prometheus</exclude>
-                                        <exclude>org.hibernate.orm:hibernate-micrometer</exclude>
-                                        <exclude>org.junit-pioneer:junit-pioneer</exclude>
                                     </excludes>
                                 </banTransitiveDependencies>
                             </rules>
@@ -908,4 +927,10 @@ SPDX-License-Identifier: MIT
             </plugin>
         </plugins>
     </reporting>
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties />
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/nl/b3p/planmonitorwonen/api/controller/HelloController.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/controller/HelloController.java
@@ -7,13 +7,18 @@ package nl.b3p.planmonitorwonen.api.controller;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
+import nl.b3p.planmonitorwonen.api.security.TMAPIAuthenticationToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,12 +30,33 @@ public class HelloController {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @RequestMapping(method = {GET})
-  public ResponseEntity<Serializable> hello() {
-    logger.debug("Hello, World!");
+  private record HelloResponse(String message, ObjectNode authResponse) implements Serializable {}
 
-    record HelloResponse(String message) implements Serializable {}
+  @RequestMapping(
+      method = {GET},
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Serializable> hello(@AuthenticationPrincipal UserDetails userDetails) {
+    final TMAPIAuthenticationToken authentication =
+        (TMAPIAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
 
-    return ResponseEntity.status(HttpStatus.OK).body(new HelloResponse("Hello, World!"));
+    logger.info("Authentication: {}", authentication);
+    logger.info("UserDetails: {}", userDetails);
+
+    if (null == authentication) {
+      // should not happen
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+          .body(new HelloResponse("Unauthorized", null));
+    }
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(
+            new HelloResponse(
+                "Hello "
+                    + authentication.getName()
+                    + " with roles: "
+                    + authentication.getAuthorities()
+                    + " and userDetails: "
+                    + userDetails,
+                authentication.getAuthResponse()));
   }
 }

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/ApiSecurityConfig.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/ApiSecurityConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity(debug = false)
+public class ApiSecurityConfig {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  @Autowired
+  public ApiSecurityConfig(ApplicationEventPublisher applicationEventPublisher) {
+    this.applicationEventPublisher = applicationEventPublisher;
+  }
+
+  @Value("${planmonitorwonen-api.base-path}")
+  private String apiBasePath;
+
+  @Bean
+  public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+    http.cors(Customizer.withDefaults())
+        // disable login/logout for this application
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
+        .csrf(AbstractHttpConfigurer::disable)
+        .logout(AbstractHttpConfigurer::disable)
+        .sessionManagement(
+            httpSecuritySessionManagementConfigurer ->
+                httpSecuritySessionManagementConfigurer.sessionCreationPolicy(
+                    SessionCreationPolicy.STATELESS))
+        .exceptionHandling(
+            httpSecurityExceptionHandlingConfigurer ->
+                httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(
+                    (request, response, authException) -> {
+                      logger.debug("Unauthorized request: {}", request, authException);
+                      response.sendError(
+                          HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+                    }));
+
+    return http.build();
+  }
+
+  @Bean(name = "tmapiAuthenticationProvider")
+  public AuthenticationProvider tmapiAuthenticationProvider() {
+    TMAPIAuthenticationProvider provider = new TMAPIAuthenticationProvider();
+    provider.setUserDetailsService(new TMAPIUserDetailsService());
+    logger.debug("Created AuthenticationProvider {}", provider);
+    return provider;
+  }
+
+  @Bean(name = "authenticationManager")
+  @DependsOn("tmapiAuthenticationProvider")
+  protected AuthenticationManager authenticationManager() {
+    return new ProviderManager(Collections.singletonList(tmapiAuthenticationProvider()));
+  }
+
+  @Bean
+  @DependsOn("authenticationManager")
+  public TMAPIAuthenticationFilter tmapiSessionCookieAuthenticationFilter() {
+    TMAPIAuthenticationFilter filter = new TMAPIAuthenticationFilter();
+    filter.setRequiresAuthenticationRequestMatcher(new AntPathRequestMatcher(apiBasePath + "/**"));
+    filter.setAuthenticationManager(authenticationManager());
+    filter.setAuthenticationDetailsSource(TMAPIAuthenticationDetails::new);
+    filter.setApplicationEventPublisher(applicationEventPublisher);
+    logger.debug("TMAPIAuthenticationFilter created with {}", filter);
+    return filter;
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationDetails.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationDetails.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.GrantedAuthoritiesContainer;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+public class TMAPIAuthenticationDetails extends WebAuthenticationDetails
+    implements GrantedAuthoritiesContainer {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final List<String> authorities;
+
+  public TMAPIAuthenticationDetails(HttpServletRequest request) {
+    super(request);
+    logger.trace("Created TMAPIAuthenticationDetails for request: {}", request.getRequestURI());
+    this.authorities = List.of();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getGrantedAuthorities() {
+    logger.trace("Returning authorities (empty collection) {}", authorities);
+    return this.authorities.stream().map(SimpleGrantedAuthority::new).toList();
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationFilter.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationFilter.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.web.WebAttributes;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * An authentication filter that checks if the request has a valid session cookie from the TM API.
+ */
+public class TMAPIAuthenticationFilter extends GenericFilterBean
+    implements ApplicationEventPublisherAware {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  // use a thread local to cache the principal for each request
+  private static final ThreadLocal<TMAPIAuthenticationToken> principalThreadLocal =
+      ThreadLocal.withInitial(() -> new TMAPIAuthenticationToken(null, null));
+
+  private ApplicationEventPublisher eventPublisher = null;
+
+  private final SecurityContextRepository securityContextRepository =
+      new HttpSessionSecurityContextRepository();
+
+  private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
+      new TMASPIAuthenticationDetailsSource();
+
+  private AuthenticationManager authenticationManager = null;
+
+  @Value("${tailormap-api.credentials.url}")
+  private String credentialsUrl;
+
+  // TODO: implement cookie path
+  //  @Value("${tailormap-api.cookie.path}")
+  //  private String cookiePath;
+
+  private RequestMatcher requiresAuthenticationRequestMatcher;
+  private final SecurityContextHolderStrategy securityContextHolderStrategy =
+      SecurityContextHolder.getContextHolderStrategy();
+
+  public void setAuthenticationDetailsSource(
+      AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+    this.authenticationDetailsSource = authenticationDetailsSource;
+  }
+
+  public void setAuthenticationManager(AuthenticationManager authenticationManager) {
+    this.authenticationManager = authenticationManager;
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    if (this.requiresAuthenticationRequestMatcher.matches((HttpServletRequest) request)) {
+      logger.debug(
+          "Authenticating {}", this.securityContextHolderStrategy.getContext().getAuthentication());
+      doAuthenticate((HttpServletRequest) request, (HttpServletResponse) response);
+    } else {
+      logger.trace(
+          "Did not authenticate since request did not match [{}]",
+          this.requiresAuthenticationRequestMatcher);
+    }
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    try {
+      super.afterPropertiesSet();
+    } catch (ServletException ex) {
+      throw new RuntimeException(ex);
+    }
+    Assert.notNull(this.authenticationManager, "An AuthenticationManager must be set");
+  }
+
+  private Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
+    logger.debug("requesting pre-authenticated principal for request: {}", request.getRequestURI());
+
+    final String sessionCookieValue = getSessionCookieValue(request);
+    if (null == sessionCookieValue || sessionCookieValue.isBlank()) {
+      logger.debug("No session cookie found in request for {}.", request.getRequestURI());
+    } else {
+      try {
+        ObjectNode authResponse = getTMAPIAuthResponse(sessionCookieValue);
+        TMAPIAuthenticationToken token = getAuthenticatedPrincipal(authResponse);
+        principalThreadLocal.set(token);
+        SecurityContextHolder.getContext().setAuthentication(token);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    logger.debug("Returning principal: {}", principalThreadLocal.get());
+    return principalThreadLocal.get().getPrincipal();
+  }
+
+  public void setRequiresAuthenticationRequestMatcher(
+      RequestMatcher requiresAuthenticationRequestMatcher) {
+    Assert.notNull(requiresAuthenticationRequestMatcher, "requestMatcher cannot be null");
+    this.requiresAuthenticationRequestMatcher = requiresAuthenticationRequestMatcher;
+  }
+
+  private String getSessionCookieValue(HttpServletRequest request) {
+    // TODO in theory a request could have more than one JSESSIONID cookies for a url,
+    //  so we would have to check all of them, for now just use the first one
+    final Cookie jSessionId =
+        request.getCookies() == null
+            ? null
+            : Arrays.stream(request.getCookies())
+                .filter(cookie -> "JSESSIONID".equals(cookie.getName()))
+                // TODO filter cookie path for the TM API
+                //  the current path is / though
+                // .filter(cookie -> cookiePath.equals(cookie.getPath()))
+                .findFirst()
+                .orElse(null);
+
+    if (null == jSessionId) {
+      return null;
+    }
+
+    logger.debug(
+        "Found JSESSIONID = {} in request {}", jSessionId.getValue(), request.getRequestURI());
+    return jSessionId.getValue();
+  }
+
+  private @NonNull ObjectNode getTMAPIAuthResponse(@NonNull String sessionCookieValue)
+      throws JsonProcessingException {
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Cookie", "JSESSIONID=%s".formatted(sessionCookieValue));
+    HttpEntity<ObjectNode> entity = new HttpEntity<>(headers);
+    // set up with default TM API unauthorized response
+    ObjectNode authResponseBody =
+        (ObjectNode) new ObjectMapper().readTree("{\"unauthorized\": true}");
+
+    try {
+      // check with TM API if the user is authenticated with the session cookie value
+      ResponseEntity<ObjectNode> authResponse =
+          restTemplate.exchange(credentialsUrl, HttpMethod.GET, entity, ObjectNode.class);
+
+      if (authResponse.getStatusCode().is2xxSuccessful() && null != authResponse.getBody()) {
+        authResponseBody = authResponse.getBody();
+        logger.trace("TM API response: {}", authResponseBody);
+        if (!authResponse.getBody().get("isAuthenticated").asBoolean()) {
+          logger.warn(
+              "User {} is not authenticated in TM API", authResponse.getBody().get("username"));
+        } else {
+          if (logger.isDebugEnabled()) {
+            logger.debug("User {} is authenticated", authResponse.getBody().get("username"));
+            authResponse
+                .getBody()
+                .get("roles")
+                .forEach(role -> logger.debug("Role from TM API: {}", role));
+          }
+        }
+      }
+
+    } catch (HttpClientErrorException e) {
+      logger.error("Error while authenticating user: {}", e.getMessage());
+    }
+
+    return authResponseBody;
+  }
+
+  private @NonNull TMAPIAuthenticationToken getAuthenticatedPrincipal(
+      @NonNull ObjectNode authResponse) {
+    final Set<GrantedAuthority> authorities = new HashSet<>();
+    Objects.requireNonNull(authResponse)
+        .get("roles")
+        .forEach(
+            role -> {
+              authorities.add(new SimpleGrantedAuthority(role.asText()));
+            });
+    return new TMAPIAuthenticationToken(
+        authResponse.get("username").asText(), null, authorities, null, authResponse);
+  }
+
+  @Override
+  public void setApplicationEventPublisher(
+      @NonNull ApplicationEventPublisher applicationEventPublisher) {
+    this.eventPublisher = applicationEventPublisher;
+    try {
+      super.afterPropertiesSet();
+    } catch (ServletException ex) {
+      // convert to RuntimeException for passivity on afterPropertiesSet signature
+      throw new RuntimeException(ex);
+    }
+    Assert.notNull(this.authenticationManager, "An AuthenticationManager must be set");
+  }
+
+  private void doAuthenticate(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    Object principal = getPreAuthenticatedPrincipal(request);
+    if (principal == null) {
+      logger.debug("No pre-authenticated principal found in request");
+      return;
+    }
+    logger.debug("pre-authenticated principal = {}, trying to authenticate", principal);
+    try {
+      TMAPIAuthenticationToken authenticationRequest = principalThreadLocal.get();
+      authenticationRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+      Authentication authenticationResult =
+          this.authenticationManager.authenticate(authenticationRequest);
+      successfulAuthentication(request, response, authenticationResult);
+    } catch (AuthenticationException ex) {
+      unsuccessfulAuthentication(request, response, ex);
+      throw ex;
+    }
+  }
+
+  protected void successfulAuthentication(
+      HttpServletRequest request, HttpServletResponse response, Authentication authResult)
+      throws IOException, ServletException {
+    logger.debug("Authentication success: {}", authResult);
+    SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
+    context.setAuthentication(authResult);
+    this.securityContextHolderStrategy.setContext(context);
+    this.securityContextRepository.saveContext(context, request, response);
+
+    if (this.eventPublisher != null) {
+      this.eventPublisher.publishEvent(
+          new InteractiveAuthenticationSuccessEvent(authResult, this.getClass()));
+    }
+  }
+
+  protected void unsuccessfulAuthentication(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException failed)
+      throws IOException, ServletException {
+    this.securityContextHolderStrategy.clearContext();
+    logger.debug("Cleared security context due to exception", failed);
+    request.setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, failed);
+    // TODO: implement failure handler
+    //        if (this.authenticationFailureHandler != null) {
+    //          this.authenticationFailureHandler.onAuthenticationFailure(request, response,
+    // failed);
+    //        }
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationProvider.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import java.lang.invoke.MethodHandles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.Ordered;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TMAPIAuthenticationProvider
+    implements AuthenticationProvider, InitializingBean, Ordered {
+
+  private int order = -1; // default: same as non-ordered
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private TMAPIUserDetailsService tmapiUserDetailsService;
+
+  @Override
+  public void afterPropertiesSet() {
+    // Assert.notNull(this.tmapiUserDetailsService, "A TMAPIUserDetailsService must be set");
+  }
+
+  public void setUserDetailsService(TMAPIUserDetailsService tmapiUserDetailsService) {
+    this.tmapiUserDetailsService = tmapiUserDetailsService;
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    logger.debug("Authenticating with TMAPIAuthenticationProvider for {}", authentication);
+
+    UserDetails details =
+        tmapiUserDetailsService.loadUserDetails((TMAPIAuthenticationToken) authentication);
+
+    logger.trace("UserDetails: {}", details);
+    logger.trace("Authentication: {}", authentication);
+
+    return new TMAPIAuthenticationToken(
+        details.getUsername(),
+        details.getPassword(),
+        details.getAuthorities(),
+        details,
+        ((TMAPIAuthenticationToken) authentication).getAuthResponse());
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    final boolean supports = TMAPIAuthenticationToken.class.isAssignableFrom(authentication);
+    logger.trace(
+        "TMAPIAuthenticationProvider {} support {}",
+        supports ? "DOES" : "DOES NOT",
+        authentication);
+    return supports;
+  }
+
+  @Override
+  public int getOrder() {
+    return this.order;
+  }
+
+  public void setOrder(int i) {
+    this.order = i;
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationToken.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIAuthenticationToken.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.GrantedAuthority;
+
+public class TMAPIAuthenticationToken extends AbstractAuthenticationToken
+    implements Authentication, CredentialsContainer {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final Object principal;
+  private final Object credentials;
+  private ObjectNode authResponse;
+
+  /**
+   * Creates an unauthenticated token.
+   *
+   * @param principal the principal to be associated with this authentication object (cannot be
+   *     {@code null})
+   * @param credentials the credentials to be associated with this authentication object
+   */
+  public TMAPIAuthenticationToken(Object principal, Object credentials) {
+    super(null);
+    this.principal = principal;
+    this.credentials = credentials;
+    setAuthenticated(false);
+  }
+
+  /**
+   * Creates an authenticated token with the supplied principal, credentials and array of
+   * authorities.
+   *
+   * @param principal the principal to be associated with this authentication object (cannot be
+   *     {@code null})
+   * @param credentials the credentials to be associated with this authentication object
+   * @param authorities the collection of {@code GrantedAuthority}s for the principal
+   * @param details additional details for the authentication request
+   * @param authResponse the authentication response from the TM API
+   */
+  public TMAPIAuthenticationToken(
+      Object principal,
+      Object credentials,
+      Collection<? extends GrantedAuthority> authorities,
+      Object details,
+      ObjectNode authResponse) {
+    super(authorities);
+    this.principal = principal;
+    this.credentials = credentials;
+    setDetails(details);
+    this.authResponse = authResponse;
+    super.setAuthenticated(true); // must use super, as we override
+  }
+
+  @Override
+  public Object getCredentials() {
+    logger.trace("credentials from token {}", this.credentials);
+    return this.credentials;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    logger.trace("principal from token {}", this.principal);
+    return this.principal;
+  }
+
+  public ObjectNode getAuthResponse() {
+    return authResponse;
+  }
+
+  public void setAuthResponse(ObjectNode authResponse) {
+    this.authResponse = authResponse;
+  }
+
+  @Override
+  public boolean isAuthenticated() {
+    if (null != this.authResponse && this.authResponse.has("isAuthenticated")) {
+      logger.debug(
+          "isAuthenticated from token {}", this.authResponse.get("isAuthenticated").asBoolean());
+      return this.authResponse.get("isAuthenticated").asBoolean();
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIUserDetails.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIUserDetails.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class TMAPIUserDetails implements UserDetails {
+  private final String username;
+  private final List<GrantedAuthority> authorities;
+
+  public TMAPIUserDetails(String username, List<GrantedAuthority> authorities) {
+    this.username = username;
+    this.authorities = authorities;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return this.authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return "N/A";
+  }
+
+  @Override
+  public String getUsername() {
+    return this.username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIUserDetailsService.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMAPIUserDetailsService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public class TMAPIUserDetailsService
+    implements AuthenticationUserDetailsService<TMAPIAuthenticationToken> {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Override
+  public UserDetails loadUserDetails(TMAPIAuthenticationToken token)
+      throws UsernameNotFoundException {
+    return this.buildUserDetails(token, token.getAuthorities());
+  }
+
+  protected UserDetails buildUserDetails(
+      TMAPIAuthenticationToken token, Collection<? extends GrantedAuthority> authorities) {
+    logger.debug("building user details for token: {}, authorities: {}", token, authorities);
+    return new TMAPIUserDetails(
+        token.getName(), authorities.stream().collect(Collectors.toUnmodifiableList()));
+  }
+}

--- a/src/main/java/nl/b3p/planmonitorwonen/api/security/TMASPIAuthenticationDetailsSource.java
+++ b/src/main/java/nl/b3p/planmonitorwonen/api/security/TMASPIAuthenticationDetailsSource.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2024 Provincie Zeeland
+ *
+ * SPDX-License-Identifier: MIT
+ */
+package nl.b3p.planmonitorwonen.api.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+public class TMASPIAuthenticationDetailsSource
+    implements AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> {
+
+  @Override
+  public WebAuthenticationDetails buildDetails(HttpServletRequest context) {
+    return new TMAPIAuthenticationDetails(context);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,20 +1,25 @@
 # base path for the API
 planmonitorwonen-api.version=@project.version@
 planmonitorwonen-api.apiVersion=@info.version@
-
 planmonitorwonen-api.base-path=/api/planmonitorwonen
-
-
+tailormap-api.cookie.path=
+tailormap-api.credentials.url=http://localhost:8080/api/user
+tailormap-api.redirect.url=http://localhost:8080/api/unauthorized
 
 # in the tailormap-viewer Docker Compose stack this is changed to 0.0.0.0
 server.address=localhost
+server.port=8081
 server.http2.enabled=true
 server.compression.enabled=true
 server.forward-headers-strategy=native
+# should not use cookie
+server.servlet.session.tracking-modes=URL
+
 
 spring.main.banner-mode=off
 spring.application.name=@project.artifactId@
 
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
 
 # Actuator
 management.endpoints.enabled-by-default=true
@@ -32,7 +37,7 @@ management.endpoint.configprops.show-values=WHEN_AUTHORIZED
 # too slow with bcrypt and http basic (~100ms password hashing each request) - use prometheus endpoint instead
 management.endpoint.metrics.enabled=false
 management.endpoint.prometheus.enabled=true
-management.metrics.tags.application=${planmonitorwonen-api.name}
+management.metrics.tags.application=${spring.application.name}
 management.metrics.tags.hostname=${HOST:localhost}
 management.metrics.data.repository.autotime.enabled=true
 management.metrics.data.repository.autotime.percentiles=0.5,0.95,0.99
@@ -42,6 +47,7 @@ management.prometheus.metrics.export.descriptions=true
 logging.level.org.springframework.boot=INFO
 logging.level.org.springframework.boot.autoconfigure=INFO
 logging.level.org.springframework.test.context=INFO
+logging.level.org.springframework.security.web.authentication=DEBUG
 
 logging.level.nl.b3p.planmonitorwonen.api=DEBUG
 

--- a/src/test/java/nl/b3p/planmonitorwonen/api/controller/HelloControllerTest.java
+++ b/src/test/java/nl/b3p/planmonitorwonen/api/controller/HelloControllerTest.java
@@ -8,9 +8,14 @@ package nl.b3p.planmonitorwonen.api.controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,24 +23,51 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @AutoConfigureMockMvc
 @SpringBootTest
 @ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HelloControllerTest {
-  @Autowired private MockMvc mockMvc;
+
+  @Autowired private WebApplicationContext context;
+
+  private MockMvc mockMvc;
 
   @Value("${planmonitorwonen-api.base-path}")
   private String basePath;
 
+  @BeforeAll
+  void initialize() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+  }
+
   @Test
   @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-  void testIndex() throws Exception {
+  @Disabled(
+      "This test is failing because we need to issue a valid TM API jsessionid cookie to pass the test.")
+  void testHelloWithUser() throws Exception {
     mockMvc
-        .perform(get(basePath + "/hello").accept(MediaType.APPLICATION_JSON))
+        .perform(
+            get(basePath + "/hello")
+                .cookie(new Cookie("JSESSIONID", "1234567890"))
+                .accept(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(content().json("{\"message\":\"Hello, World!\"}"));
+        .andExpect(jsonPath("$.message").value("Hello ..."));
+  }
+
+  @Test
+  @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+  void testHello() throws Exception {
+    mockMvc
+        .perform(get(basePath + "/hello").accept(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().is4xxClientError())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json("{\"message\":\"Unauthorized\",\"authResponse\":null}"));
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,6 +3,9 @@ planmonitorwonen-api.apiVersion=@info.version@
 
 planmonitorwonen-api.base-path=/api/planmonitorwonen
 
+tailormap-api.credentials.url=http://localhost:8080/api/user
+tailormap-api.redirect.url=http://localhost:8080/api/unauthorized
+tailormap-api.cookie.path=
 management.endpoints.web.base-path=/api/planmonitorwonen/actuator
 
 spring.profiles.active=test
@@ -12,5 +15,7 @@ spring.main.banner-mode=off
 
 # we don't need JMX
 spring.jmx.enabled=false
+
+logging.level.org.springframework.security.web.authentication=DEBUG
 
 logging.level.nl.b3p.planmonitorwonen.api=TRACE


### PR DESCRIPTION
Gebruiker hoeft niet 2x in te loggen.

resolves PMW-8

## how this works for now
- start the TM API with `mvn -Pdeveloping,hal-explorer spring-boot:run -Dspring-boot.run.profiles=dev` or from your ide
- go to http://localhost:8080/api/admin/ and login using the following snippet eg through the browsers dev console:
```javascript
fetch("http://localhost:8080/api/login", {
  "headers": {
    "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
  },
  "referrer": "http://localhost:8080/api/login",
  "body": "username=tm-admin&password=tm-admin",
  "method": "POST"
});
```
- go to http://localhost:8081/api/planmonitorwonen/hello in a new or the same browser tab or `curl -v --cookie "JSESSIONID=89A66A5CC56ADA82B425CD5A08C1E4EB" http://localhost:8081/api/planmonitorwonen/hello` where the sessionid cookie is that of  http://localhost:8080/api/admin/

the PMW API will contact the TM API for the user credentials through http://localhost:8080/api/user

note that any urls can be modified using the property files and must be for a deployment scenario.