### PR TITLE
Dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,6 @@ SPDX-License-Identifier: MIT
         -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <flyway.version>10.20.1</flyway.version>
-        <jackson-bom.version>2.17.2</jackson-bom.version>
         <micrometer.version>1.14.2</micrometer.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <postgresql.version>42.7.4</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
-        <commons-lang3.version>3.17.0</commons-lang3.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <postgresql.version>42.7.4</postgresql.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
-        <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <postgresql.version>42.7.4</postgresql.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
-        <postgresql.version>42.7.4</postgresql.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-deploy-plugin.version>3.1.0</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
-        <flyway.version>10.20.1</flyway.version>
         <micrometer.version>1.14.2</micrometer.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <postgresql.version>42.7.4</postgresql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@ SPDX-License-Identifier: MIT
         to check
         -->
         <commons-lang3.version>3.17.0</commons-lang3.version>
-        <micrometer.version>1.14.2</micrometer.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <postgresql.version>42.7.4</postgresql.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>


### PR DESCRIPTION
Remove some unnecessary version overrides, as the parent now provides these:
- remove Jackson version override
- remove Flyway version override
- remove Micrometer version override
- remove Commons Lang3 version override
- remove JUnit version override
- remove PostgreSQL driver version override