### PR TITLE
PMW-48: Fix pgjdbc Client Allows Fallback to Insecure Authentication Despite `channelBinding=require` Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@ SPDX-License-Identifier: MIT
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-plugin-updates
         to check
         -->
+        <postgresql.version>42.7.7</postgresql.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
[![PMW-48](https://badgen.net/badge/JIRA/PMW-48/pink?icon=jira)](https://b3partners.atlassian.net/browse/PMW-48) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=B3Partners&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

